### PR TITLE
Fix build and run

### DIFF
--- a/Infraestructura/ErrorFixer.cs
+++ b/Infraestructura/ErrorFixer.cs
@@ -371,7 +371,6 @@ IMPORTANTE: El objetivo es que el archivo resultante compile correctamente.
         private bool IsPathPotentiallyValid(string? filePath) { return !string.IsNullOrWhiteSpace(filePath); }
         private bool IsPathWritable(string filePath, string projectRootPath) { if (!IsPathPotentiallyValid(filePath)) return false; try { string fullPath = Path.GetFullPath(filePath); string fullProjectRootPath = Path.GetFullPath(projectRootPath); if (!fullPath.StartsWith(fullProjectRootPath, StringComparison.OrdinalIgnoreCase)) { _logger.LogWarning("Attempted to write outside project directory: {FullPath}", fullPath); return false; } string[] protectedPaths = { Path.Combine("C:", "Program Files"), Path.Combine("C:", "Program Files (x86)"), Path.Combine("C:", "Windows"), "/usr/bin", "/usr/sbin", "/bin", "/sbin", "/etc", Path.Combine("dotnet", "sdk") }; if (protectedPaths.Any(p => fullPath.Contains(p, StringComparison.OrdinalIgnoreCase))) { _logger.LogWarning("Attempted to write to a potentially protected system path: {FullPath}", fullPath); return false; } string? directory = Path.GetDirectoryName(fullPath); if (directory == null || !Directory.Exists(directory)) { _logger.LogWarning("Target directory for writing does not exist: {Directory}", directory ?? "N/A"); return false; } return true; } catch (Exception ex) { _logger.LogWarning(ex, "Exception while checking if path is writable: {FilePath}", filePath); return false; } }
 
-        #endregion
 
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,22 @@
 # TERMINATOR
 
+This repository contains a multi-project .NET solution. The projects target .NET 9.0, which may not be preinstalled on all systems. If `dotnet` is missing, you can download a .NET 9 SDK tarball and extract it locally:
+
+```bash
+wget https://builds.dotnet.microsoft.com/dotnet/Sdk/9.0.300/dotnet-sdk-9.0.300-linux-x64.tar.gz
+mkdir -p $HOME/dotnet && tar zxf dotnet-sdk-9.0.300-linux-x64.tar.gz -C $HOME/dotnet
+export DOTNET_ROOT=$HOME/dotnet
+export PATH=$DOTNET_ROOT:$PATH
+```
+
+Then build the solution:
+
+```bash
+dotnet build DesarrolladorAutonomo.sln
+```
+
+And run the API:
+
+```bash
+dotnet run --project AgentAPI
+```


### PR DESCRIPTION
## Summary
- fix stray `#endregion` causing build error in `ErrorFixer`
- confirm project builds and runs on .NET 9
- document how to install a local .NET 9 SDK and run the solution

## Testing
- `dotnet build DesarrolladorAutonomo.sln`
- `dotnet run --project AgentAPI`

------
https://chatgpt.com/codex/tasks/task_e_6840b2263d588330817908a2fe7c2e29